### PR TITLE
Witness: add option to encode account with codesize/codehash but witout code

### DIFF
--- a/witness.md
+++ b/witness.md
@@ -195,8 +195,10 @@ Next, recursively define the encoding for an Ethereum state tree node, with some
 
 <Account_Node(d<65)> := 0x00 pathnibbles:<Nibbles(64-d)> address:<Address> balance:<Bytes32> nonce:<Bytes32>
                         {account node for externally owned account with values (pathnibbles, address, balance, nonce)}
-                      | 0x01 pathnibbles:<Nibbles(64-d)> address:<Address> balance:<Bytes32> nonce:<Bytes32> bytecode:<Bytecode> storage:<Account_Storage_Tree_Node(0)>
-                        {account node for contract account with values (pathnibbles address balance nonce bytecode storage)}
+                      | 0x01 pathnibbles:<Nibbles(64-d)> address:<Address> balance:<Bytes32> nonce:<Bytes32> code:<Bytecode> storage:<Account_Storage_Tree_Node(0)>
+                        {account node for executed contract account with values (pathnibbles address balance nonce code storage)}
+                      | 0x02 pathnibbles:<Nibbles(64-d)> address:<Address> balance:<Bytes32> nonce:<Bytes32> codehash:<Bytes32> codesize:<U32> storage:<Account_Storage_Tree_Node(0)>
+                        {account node for contract account with values (pathnibbles address balance nonce codehash codesize storage)}
 
 <Bytecode> := len:<U32> b:<Byte>^len
               {byte array b of length len}


### PR DESCRIPTION
This adds an option to encode an account with codesize and codehash, but without code. This is useful for the case when an account is "touched", but not executed.

However, if we were to change the meaning of `Bytecode` to "merkleized-bytecode", then it would be preferable to encode `codesize` and `codehash` next to the merklized bytecode, otherwise in most cases,  all code needs to be submitted.