### PR TITLE
Gichiba/witness spec language

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Specifications for the Stateless Ethereum research effort
 
 ## Background
 
-[Vitalik Buterin](https://ethresear.ch/u/vbuterin/summary) proposed the [Stateless Client Concept](https://ethresear.ch/t/the-stateless-client-concept/172) in October 2017. The purpose of the Stateless Client Concept is to create a new type of full Ethereum node that is no longer required to store the state of the entire blockchain. 
+[Vitalik Buterin](https://ethresear.ch/u/vbuterin/summary) proposed the [Stateless Client Concept](https://ethresear.ch/t/the-stateless-client-concept/172) in October 2017. The purpose of the Stateless Client Concept is to create a new type of full Ethereum node that is no longer required to store the state of the entire blockchain.
 
-Instead, miners would provide each mined block with the minimal information that is required to prove that block’s validity and to do a particular state transition. Such information is known as a witness. Witnesses are a set of Merkle branches proving the values of all data that the execution of the block accesses. 
+Instead, miners would provide each mined block with the minimal information that is required to prove that block’s validity and to do a particular state transition. Such information is known as a witness. Witnesses are a set of Merkle branches proving the values of all data that the execution of the block accesses.
 
 We encode the witness, the set of Merkle branches, as instructions. The block validator parses these instructions and constructs these Merkle branches, in order to check validity. Block validity is checked by constructing a partial Merkle tree using:
 
@@ -33,6 +33,7 @@ Therefore, block witnesses would allow stateless nodes to store only state roots
 ### Overview & Concepts
 
 * https://blog.ethereum.org/2019/12/30/eth1x-files-state-of-stateless-ethereum/
+* https://blog.ethereum.org/2020/05/04/eth1x-witness-primer/
 * https://medium.com/@pipermerriam/stateless-clients-a-new-direction-for-ethereum-1-x-e70d30dc27aa
 * https://medium.com/@akhounov/on-the-state-rent-and-pivot-to-stateless-ethereum-ab4d967ff630
 * https://medium.com/@akhounov/the-shades-of-statefulness-in-ethereum-nodes-697b0f88cd04
@@ -44,6 +45,3 @@ Therefore, block witnesses would allow stateless nodes to store only state roots
 * https://medium.com/@mandrigin/semi-stateless-initial-sync-experiment-897cc9c330cb
 * https://ethresear.ch/t/some-quick-numbers-on-code-merkelization/7260
 * https://medium.com/ewasm/evm-bytecode-merklization-2a8366ab0c90
-
-
-

--- a/witness.md
+++ b/witness.md
@@ -5,18 +5,18 @@ Block Witness Formal Specification
 
 ## 1.1. Design Goals
 
-### 1.1.1. Semantics
+**1.1. Describe the witness format fully.**
+    Ensures consistent implementation of witness support in multiple clients, regardless of the programming language used.
 
-**2. Highlight changes to the witness format.**
+**1.2. Highlight changes to the witness format.**
      Makes it clear how changes to the witness format affects witness generation and parsing rules.
 
-**Platform-independent.** The semantics shouldn't depend on features of
-specific programming platforms or operating systems.
+**1.3. Provide the single, authoritative place to discuss the format, including proposed and future improvements.**
 
-**4. Formal analysis.**
+**1.4. Formal analysis.**
      Helps claim, prove, and review correctness of the format. Additionally, using complexity theoretic metrics, analyses the performance of witness generation and parsing rules.
 
-**5. Reference tests.**
+**1.5. Reference tests.**
      Helps to construct a minimal set of test witnesses, which can be encoded and decoded using the current witness format. These test witnesses serve as reference tests for witness format generators and parsers that are included in a client.
 
 ### 1.1.2. Representation

--- a/witness.md
+++ b/witness.md
@@ -5,41 +5,24 @@ Block Witness Formal Specification
 
 ## 1.1. Design Goals
 
-**1.1. Describe the witness format fully.**
-    Ensures consistent implementation of witness support in multiple clients, regardless of the programming language used.
+### 1.1.1. Semantics
 
-**1.2. Highlight changes to the witness format.**
-     Makes it clear how changes to the witness format affects witness generation and parsing rules.
+**Language-independent.** The semantics shouldn't depend on features of
+specific programming languages.
 
-**1.3. Provide the single, authoritative place to discuss the format, including proposed and future improvements.**
+**Platform-independent.** The semantics shouldn't depend on features of
+specific programming platforms or operating systems.
 
-**1.4. Formal analysis.**
-     Helps claim, prove, and review correctness of the format. Additionally, using complexity theoretic metrics, analyses the performance of witness generation and parsing rules.
+**Hardware-independent.** The semantics shouldn't depend on features of
+specific hardware platforms.
 
-**1.5. Reference tests.**
-     Helps to construct a minimal set of test witnesses, which can be encoded and decoded using the current witness format. These test witnesses serve as reference tests for witness format generators and parsers that are included in a client.
+**Well defined.** The semantics should fully and precisely define valid witnesses in a way that is easy to reason about.
 
 ### 1.1.2. Representation
 
 **Efficient.** Witness should be decoded, validated and executed in a single pass with minimum dynamic memory allocation.
 
 **Streamable (without intermediate dynamic buffers).** It should be possible to 'stream-as-you-encode' the trie on one node, and recreate it at the same time, by using a fixed allocated buffer. That helps to efficiently transfer and encode/decode witnesses.
-
-**2.2. Verifiability.**
-The code must be able to verify the multiproof encoded in the witness against
-the block header.
-
-**2.3. Chunking support.**
-It should be possible to split witness in chunks that are independently
-verifiable to speed-up witness propagation in the network.
-
-The witness format doesn't limit a chunk size. That makes it easy to experiment with and find
-the best size for efficient relaying properties.
-
-**2.4. Witness Streaming without intermediate dynamic buffers.**
-It should be possible to 'stream-as-you-encode' the trie on one node,
-and recreate it at the same time, by using a fixed allocated buffer. That helps
-to efficiently transfer and encode/decode witnesses.
 
 The witness allows you to walk through the trie and to produce the witness as you go without buffering;
 sending it straight to a network socket. A peer can then receive it from the socket
@@ -48,13 +31,9 @@ and start computing the hash of the state root straight away.
 Also, it means that the memory consumption of witness processing itself will be
 fixed and predictable, which helps nodes that have limited memory.
 
-**2.5. Building a forest.**
-It should be possible to build a forest of tries from a single witness. It is
-needed for two use cases:
+**Chunkable.** It should be possible to split witness in chunks that are independently verifiable to speed-up witness propagation in the network.
 
-- partial witnesses (like the ones that are used in a
-semi-stateless initial sync, when you already have some trie that you need to
-extend with more data);
+The witness format doesn't limit a chunk size. That makes it easy to experiment with and find the best size for efficient relaying properties.
 
 **Upgradeable.** It should be able to upgrade witness format in the future in a backward compatible way (e.g. new versions of clients will support the old versions of the witness). Old versions of clients should be able to discard unsupported
 versions of witness.
@@ -252,6 +231,12 @@ Next, recursively define the encoding for all Ethereum trie nodes, with some nod
 
 
 # 3. Execution
+
+TBD
+
+# 4. Properties
+
+## 4.1. Unambiguity
 
 For a witness `w`, we write `<Block_Witness> ::=* w`, to mean that the non-terminal `<Block_Witness>` derives `w` in one or many steps. In general, there can exist many ways to derive a given `w`. Each derivation is modeled by a parse tree. If there is any witness with more than one parse tree, then the grammar is termed ambiguous. If there exist exactly one parse tree for every sentence derived from the grammar, then the grammar is termed unambiguous.
 

--- a/witness.md
+++ b/witness.md
@@ -103,7 +103,7 @@ syntax, but it could be represented as classes and functions of a programming
 language used to implement witnesses support.
 
 **Execution** is the phase, where the multiproof is being built from the
-specified block witness. 
+specified block witness.
 
 **Validation** of the witness is happening during both decoding and execution.
 - *Validation while decoding* checks that the witness binary representation only contains opcodes valid for specified version and that serialized data matches the defined syntax.
@@ -193,7 +193,7 @@ The designated starting non-terminal is `<Block_Witness>`.
 
 ```
 <Block_Witness> ::= v:<Version> t:<Tree>^*
-                   {tuple of witness trees t}
+                   {tuple of witness tries t}
                    Where we exhaust all bytes available.
 
 <Version> ::= 0x01
@@ -209,7 +209,7 @@ The designated starting non-terminal is `<Block_Witness>`.
               Where the 0x01 case is disallowed in a block witnesses, but allowed for extending this spec.
 ```
 
-Next, recursively define the encoding for all Ethereum trie nodes, with some nodes possibly replaced by their merkle hash. Following the yellowpaper section 4.1 and appendix D, the tree has three types of nodes: branch, extension, and leaf. Add a fourth type of node which can replace any node with the merkle hash of the subtrie rooted at that node. Note that the parametrization variable `d` represents the nibble-depth and `s` represents a flag which is `0` when this node is in the account tree and `1` when in a storage trie.
+Next, recursively define the encoding for all Ethereum trie nodes, with some nodes possibly replaced by their merkle hash. Following the yellowpaper section 4.1 and appendix D, the trie has three types of nodes: branch, extension, and leaf. Add a fourth type of node which can replace any node with the merkle hash of the subtrie rooted at that node. Note that the parametrization variable `d` represents the nibble-depth and `s` represents a flag which is `0` when this node is in the account trie and `1` when in a storage trie.
 
 ```
 <Tree_Node(d<65,s<2)> ::= 0x00 b:<Branch_Node(d,s)>

--- a/witness.md
+++ b/witness.md
@@ -253,7 +253,7 @@ Next, recursively define the encoding for all Ethereum trie nodes, with some nod
 
 # 3. Execution
 
-For a witness `w`, we write `<Block_Witness> ::=* w`, to mean that the non-terminal `<Block_Witness>` derives `w` in one or many steps. In general, there can exist many ways to derive a given `w`. Each derivation is modeled by a parse tree. If there is any witness with more than one parse trees, then the grammar is termed ambiguous. If there exist exactly one parse tree for every sentence derived from the grammar, then the grammar is termed unambiguous.
+For a witness `w`, we write `<Block_Witness> ::=* w`, to mean that the non-terminal `<Block_Witness>` derives `w` in one or many steps. In general, there can exist many ways to derive a given `w`. Each derivation is modeled by a parse tree. If there is any witness with more than one parse tree, then the grammar is termed ambiguous. If there exist exactly one parse tree for every sentence derived from the grammar, then the grammar is termed unambiguous.
 
 Claim: The witness grammar is unambiguous.
 

--- a/witness.md
+++ b/witness.md
@@ -121,7 +121,7 @@ With each syntax rule, we may also give additional restrictions, which we refer 
 
 First, we define the notation which will be used to define the syntax, semantics, and validation rules.
 
- - We use Backus-Naur form notation, namely symbols like `|`, `::=`, `>`, and `<` are used to define production rules.
+ - We use [Backus-Naur form](https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form) notation, namely symbols like `|`, `::=`, `>`, and `<` are used to define production rules.
  - Because this is a binary format, the only terminal symbols are bytes, which we write in hexadecimal notation `0x00`, `0x01`, ..., and `0xff`.
  - Parentheses `(` and `)` enclose a tuple.
  - Brackets `[` and `]` are used to index an element of a tuple, for example the `i`th element of tuple `T` is denoted `T[i]`.

--- a/witness.md
+++ b/witness.md
@@ -127,7 +127,7 @@ First, we define the notation which will be used to define the syntax, semantics
  - Brackets `[` and `]` are used to index an element of a tuple, for example the `i`th element of tuple `T` is denoted `T[i]`.
  - Brackets following a variable named `bitmask` means that the index is of a bit, e.g. `bitmask[0]` represents the leftmost bit.
  - Ellipses `...` are notation for "and so on until", and are used to avoid writing a long enumerated tuple. For example, `A[1] A[2] ... A[5]` is short-hand notation for `A[1] A[2] A[3] A[4] A[5]`.
- - `A^n` represents symbol `A` repeated `n` times. We allow `n` to be `0`, representing zero occurances of `A`. Also, if there is a logical expression in place of `n`, then a false expression is replaced by `0` and a true expression is replaced with `1`.
+ - `A^n` represents symbol `A` repeated `n` times. We allow `n` to be `0`, representing zero occurrences of `A`. Also, if there is a logical expression in place of `n`, then a false expression is replaced by `0` and a true expression is replaced with `1`.
  - `A^+` represents symbol `A` repeated one or more times.
  - `A^*` represents symbol `A` repeated zero or more times.
  - Curly braces `{` and `}` enclose semantics after each syntax rule.
@@ -209,7 +209,7 @@ The designated starting non-terminal is `<Block_Witness>`.
               Where the 0x01 case is disallowed in a block witnesses, but allowed for extending this spec.
 ```
 
-Next, recursively define the encoding for an Ethereum tree nodes, with some nodes possibly replaced by their merkle hash. Following the yellowpaper section 4.1 and appendix D, the tree has three types of nodes: branch, extension, and leaf. Add a fourth type of node which can replace any node with the merkle hash of the subtree rooted at that node. Note that the parametrization variable `d` represents the nibble-depth and `s` represents a flag which is `0` when this node is in the account tree and `1` when in a storage tree.
+Next, recursively define the encoding for all Ethereum trie nodes, with some nodes possibly replaced by their merkle hash. Following the yellowpaper section 4.1 and appendix D, the tree has three types of nodes: branch, extension, and leaf. Add a fourth type of node which can replace any node with the merkle hash of the subtrie rooted at that node. Note that the parametrization variable `d` represents the nibble-depth and `s` represents a flag which is `0` when this node is in the account tree and `1` when in a storage trie.
 
 ```
 <Tree_Node(d<65,s<2)> ::= 0x00 b:<Branch_Node(d,s)>
@@ -253,7 +253,7 @@ Next, recursively define the encoding for an Ethereum tree nodes, with some node
 
 # 3. Execution
 
-For a witness `w`, we write `<Block_Witness> ::=* w`, to mean that the non-terminal `<Block_Witness>` derives `w` in one or many steps. In general, there can exist many ways to derive a given `w`. Each derivation is modelled by a parse tree. If there is any witness with more than one parse trees, then the grammar is termed ambiguous. If there exist exactly one parse tree for every sentence derived from the grammar, then the grammar is termed unambiguous.
+For a witness `w`, we write `<Block_Witness> ::=* w`, to mean that the non-terminal `<Block_Witness>` derives `w` in one or many steps. In general, there can exist many ways to derive a given `w`. Each derivation is modeled by a parse tree. If there is any witness with more than one parse trees, then the grammar is termed ambiguous. If there exist exactly one parse tree for every sentence derived from the grammar, then the grammar is termed unambiguous.
 
 Claim: The witness grammar is unambiguous.
 

--- a/witness.md
+++ b/witness.md
@@ -7,22 +7,39 @@ Block Witness Formal Specification
 
 ### 1.1.1. Semantics
 
-**Language-independent.** The semantics shouldn't depend on features of
-specific programming languages.
+**2. Highlight changes to the witness format.**
+     Makes it clear how changes to the witness format affects witness generation and parsing rules.
 
 **Platform-independent.** The semantics shouldn't depend on features of
 specific programming platforms or operating systems.
 
-**Hardware-independent.** The semantics shouldn't depend on features of
-specific hardware platforms.
+**4. Formal analysis.**
+     Helps claim, prove, and review correctness of the format. Additionally, using complexity theoretic metrics, analyses the performance of witness generation and parsing rules.
 
-**Well defined.** The semantics should fully and precisely define valid witnesses in a way that is easy to reason about.
+**5. Reference tests.**
+     Helps to construct a minimal set of test witnesses, which can be encoded and decoded using the current witness format. These test witnesses serve as reference tests for witness format generators and parsers that are included in a client.
 
 ### 1.1.2. Representation
 
 **Efficient.** Witness should be decoded, validated and executed in a single pass with minimum dynamic memory allocation.
 
 **Streamable (without intermediate dynamic buffers).** It should be possible to 'stream-as-you-encode' the trie on one node, and recreate it at the same time, by using a fixed allocated buffer. That helps to efficiently transfer and encode/decode witnesses.
+
+**2.2. Verifiability.**
+The code must be able to verify the multiproof encoded in the witness against
+the block header.
+
+**2.3. Chunking support.**
+It should be possible to split witness in chunks that are independently
+verifiable to speed-up witness propagation in the network.
+
+The witness format doesn't limit a chunk size. That makes it easy to experiment with and find
+the best size for efficient relaying properties.
+
+**2.4. Witness Streaming without intermediate dynamic buffers.**
+It should be possible to 'stream-as-you-encode' the trie on one node,
+and recreate it at the same time, by using a fixed allocated buffer. That helps
+to efficiently transfer and encode/decode witnesses.
 
 The witness allows you to walk through the trie and to produce the witness as you go without buffering;
 sending it straight to a network socket. A peer can then receive it from the socket
@@ -31,9 +48,13 @@ and start computing the hash of the state root straight away.
 Also, it means that the memory consumption of witness processing itself will be
 fixed and predictable, which helps nodes that have limited memory.
 
-**Chunkable.** It should be possible to split witness in chunks that are independently verifiable to speed-up witness propagation in the network.
+**2.5. Building a forest.**
+It should be possible to build a forest of tries from a single witness. It is
+needed for two use cases:
 
-The witness format doesn't limit a chunk size. That makes it easy to experiment with and find the best size for efficient relaying properties.
+- partial witnesses (like the ones that are used in a
+semi-stateless initial sync, when you already have some trie that you need to
+extend with more data);
 
 **Upgradeable.** It should be able to upgrade witness format in the future in a backward compatible way (e.g. new versions of clients will support the old versions of the witness). Old versions of clients should be able to discard unsupported
 versions of witness.
@@ -100,10 +121,10 @@ With each syntax rule, we may also give additional restrictions, which we refer 
 
 First, we define the notation which will be used to define the syntax, semantics, and validation rules.
 
- - We use Backus-Naur form notation, namely symbols like `|`, `:=`, `>`, and `<` are used to define production rules.
+ - We use Backus-Naur form notation, namely symbols like `|`, `::=`, `>`, and `<` are used to define production rules.
  - Because this is a binary format, the only terminal symbols are bytes, which we write in hexadecimal notation `0x00`, `0x01`, ..., and `0xff`.
- - Parentheses `(` and `)` enclose a tuple. 
- - Brackets `[` and `]` are used to index an element of a tuple, for example the `i`th element of tuple `T` is denoted `T[i]`. 
+ - Parentheses `(` and `)` enclose a tuple.
+ - Brackets `[` and `]` are used to index an element of a tuple, for example the `i`th element of tuple `T` is denoted `T[i]`.
  - Brackets following a variable named `bitmask` means that the index is of a bit, e.g. `bitmask[0]` represents the leftmost bit.
  - Ellipses `...` are notation for "and so on until", and are used to avoid writing a long enumerated tuple. For example, `A[1] A[2] ... A[5]` is short-hand notation for `A[1] A[2] A[3] A[4] A[5]`.
  - `A^n` represents symbol `A` repeated `n` times. We allow `n` to be `0`, representing zero occurances of `A`. Also, if there is a logical expression in place of `n`, then a false expression is replaced by `0` and a true expression is replaced with `1`.
@@ -125,23 +146,23 @@ First, we define the notation which will be used to define the syntax, semantics
 The only terminal symbols are 8-bit bytes, represented in hexadecimal notation. First define some base non-terminals to simplify later non-terminals.
 
 ```
-<Byte> := 0x00        {byte with value 0x00}
+<Byte> ::= 0x00        {byte with value 0x00}
         | 0x01        {byte with value 0x01}
         | ...
         | 0xff        {byte with value 0xff}
 
 <U32> := u32:<Byte>^4		{u32 as a 32-bit unsigned integer in big-endian}
 
-<Bytes32> := b:<Byte>^32	{byte array b in big-endian}
+<Bytes32> ::= b:<Byte>^32	{byte array b in big-endian}
 
-<Address> := b:<Byte>^20	{byte array b in big-endian}
+<Address> ::= b:<Byte>^20	{byte array b in big-endian}
 
-<Byte_Nonzero> := 0x01          {byte with value 0x01}
+<Byte_Nonzero> ::= 0x01          {byte with value 0x01}
                 | 0x02          {byte with value 0x02}
                 | ...
                 | 0xff          {byte with value 0xff}
 
-<Byte_More_Than_One_Bit_Set> := 0x03          {byte with value 0x03}
+<Byte_More_Than_One_Bit_Set> ::= 0x03          {byte with value 0x03}
                               | 0x05          {byte with value 0x05}
                               | 0x06          {byte with value 0x06}
                               | 0x07          {byte with value 0x07}
@@ -154,15 +175,15 @@ The only terminal symbols are 8-bit bytes, represented in hexadecimal notation. 
                               | ...
                               | 0xff          {byte with value 0xff}
 
-<Bytes2_More_Than_One_Bit_Set> := b1:<Byte> b2case1:<Byte>^numbits(b1)>1 b2case2:<Byte_Nonzero>^numbits(b1)==1 b2case3:<Byte_More_Than_One_Bit_Set>^numbits(b1)==0
+<Bytes2_More_Than_One_Bit_Set> ::= b1:<Byte> b2case1:<Byte>^numbits(b1)>1 b2case2:<Byte_Nonzero>^numbits(b1)==1 b2case3:<Byte_More_Than_One_Bit_Set>^numbits(b1)==0
                                   {byte array b1||b2case1||b2case2||b2case3}
 
-<Byte_Lower_Nibble_Zero> := 0x00    {byte with value 0x00}
+<Byte_Lower_Nibble_Zero> ::= 0x00    {byte with value 0x00}
                           | 0x10    {byte with value 0x10}
                           | ...
                           | 0xf0    {byte with value 0xf0}
 
-<Nibbles(n<65)> := nibbles:<Byte>^(n//2) overflownibble:<Byte_Lower_Nibble_Zero>^(n%2)
+<Nibbles(n<65)> ::= nibbles:<Byte>^(n//2) overflownibble:<Byte_Lower_Nibble_Zero>^(n%2)
                    {byte array nibbles||overflownibble}
 
 
@@ -171,17 +192,17 @@ The only terminal symbols are 8-bit bytes, represented in hexadecimal notation. 
 The designated starting non-terminal is `<Block_Witness>`.
 
 ```
-<Block_Witness> := v:<Version> t:<Tree>^*
+<Block_Witness> ::= v:<Version> t:<Tree>^*
                    {tuple of witness trees t}
                    Where we exhaust all bytes available.
 
-<Version> := 0x01
+<Version> ::= 0x01
              {the version byte 0x01}
 
 <Tree> := m:<Metadata> n:<Tree_Node(0)>
           {a tuple (m, n)}
 
-<Metadata> := 0x00
+<Metadata> ::= 0x00
               {nothing}
             | 0x01 lenid:<U32> id:<Byte>^lenid lendata:<U32> data:<Byte>^lendata
               {a tuple (id, data)}
@@ -191,7 +212,7 @@ The designated starting non-terminal is `<Block_Witness>`.
 Next, recursively define the encoding for an Ethereum tree nodes, with some nodes possibly replaced by their merkle hash. Following the yellowpaper section 4.1 and appendix D, the tree has three types of nodes: branch, extension, and leaf. Add a fourth type of node which can replace any node with the merkle hash of the subtree rooted at that node. Note that the parametrization variable `d` represents the nibble-depth and `s` represents a flag which is `0` when this node is in the account tree and `1` when in a storage tree.
 
 ```
-<Tree_Node(d<65,s<2)> := 0x00 b:<Branch_Node(d,s)>
+<Tree_Node(d<65,s<2)> ::= 0x00 b:<Branch_Node(d,s)>
                          {branch node b}
                        | 0x01 e:<Extension_Node(d,s)>
                          {extension node e}
@@ -200,18 +221,18 @@ Next, recursively define the encoding for an Ethereum tree nodes, with some node
                        | 0x03 h:<Bytes32>
                          {hash node with merkle hash h}
 
-<Branch_Node(d<64,s<2)> := bitmask:<Bytes2_More_Than_One_Bit_Set> c[0]:<Tree_Node(d+1,s)>^bitmask[0]==1 c[1]:<Tree_Node(d+1,s)>^bitmask[1]==1 ... c[15]:<Tree_Node(d+1,s)>^bitmask[15]==1
+<Branch_Node(d<64,s<2)> ::= bitmask:<Bytes2_More_Than_One_Bit_Set> c[0]:<Tree_Node(d+1,s)>^bitmask[0]==1 c[1]:<Tree_Node(d+1,s)>^bitmask[1]==1 ... c[15]:<Tree_Node(d+1,s)>^bitmask[15]==1
                       {branch node with children nodes (c[0], c[1], ..., c[15]), note that some children may be empty based on the bitmask}
 
-<Extension_Node(d<63,s<2)> := nibbleslen:<Byte_Nonzero> nibbles:<Nibbles(nibbleslen)> child:<Child_Of_Extension_Node(d+nibbleslen,s)>
+<Extension_Node(d<63,s<2)> ::= nibbleslen:<Byte_Nonzero> nibbles:<Nibbles(nibbleslen)> child:<Child_Of_Extension_Node(d+nibbleslen,s)>
                               {extension node with values (nibbleslen, nibbles, child)}
 
-<Child_Of_Extension_Node(d<65,s<2)> := 0x00 b:<Branch_Node(d,s)>
+<Child_Of_Extension_Node(d<65,s<2)> ::= 0x00 b:<Branch_Node(d,s)>
                                        {branch node b}
                                      | 0x03 h:<Bytes32>
                                        {hash node with merkle hash h}
 
-<Leaf_Node(d<65,s<2)> := accountleaf:<Account_Node(d)>^s==0 storageleaf:<Storage_Leaf_Node(d)>^s==1
+<Leaf_Node(d<65,s<2)> ::= accountleaf:<Account_Node(d)>^s==0 storageleaf:<Storage_Leaf_Node(d)>^s==1
                          {leaf node accountleaf or storageleaf, depending on whether s==0 or s==1}
 
 <Account_Node(d<65)> := 0x00 address:<Address> balance:<Bytes32> nonce:<Bytes32>
@@ -232,15 +253,9 @@ Next, recursively define the encoding for an Ethereum tree nodes, with some node
 
 # 3. Execution
 
-TBD
+For a witness `w`, we write `<Block_Witness> ::=* w`, to mean that the non-terminal `<Block_Witness>` derives `w` in one or many steps. In general, there can exist many ways to derive a given `w`. Each derivation is modelled by a parse tree. If there is any witness with more than one parse trees, then the grammar is termed ambiguous. If there exist exactly one parse tree for every sentence derived from the grammar, then the grammar is termed unambiguous.
 
-# 4. Properties
-
-## 4.1. Unambiguity
-
-For a witness `w`, we write `<Block_Witness> :=* w`, to mean that the non-terminal `<Block_Witness>` derives `w` in one or many steps. In general, there can exist many ways to derive a given `w`. Each derivation is modelled by a parse tree. If there is any witness with more than one parse trees, then the grammar is termed ambiguous. If there exist exactly one parse tree for every sentence derived from the grammar, then the grammar is termed unambiguous.
-
-Claim: The witness grammar is unambiguous. 
+Claim: The witness grammar is unambiguous.
 
 Proof: The rules with a single body cannot introduce ambiguity. Consider the rules with multiple bodies, rules for the non-terminals `<Byte>`, `<Byte_Nonzero>`, `<Byte_More_Than_One_Bit_Set>`, `<Bytes2_More_Than_One_Bit_Set>`, `<Byte_Lower_Nibble_Zero>`, `<Metadata>`, `<Tree_Node(d)>`, `<Child_Of_Extension_Node(d)>`, `<Account_Node(d)>`, `Account_Storage_Tree_Node(d)>`, and `<Child_Of_Account_Storage_Extension_Node(d)>`. The first byte determines the choice of the rule to be applied. So, the above grammar is LL(1), meaning there is at most one rule in the parsing table. Hence, the grammar is unambiguous by construction.
 


### PR DESCRIPTION
This is just a few changes I thought appropriate while working on the witness primer. 

In particular I noticed that the Backus-Naur notation in the spec uses `:=` when it seems the proper notation is to use `::=`

Other minor spelling changes are included, as well as a link to the primer in the README. 