### PR TITLE
Witness: clean up, conciseness, clarity.

### DIFF
--- a/witness.md
+++ b/witness.md
@@ -105,21 +105,19 @@ First, we define the notation which will be used to define the syntax, semantics
  - We use [Backus-Naur form](https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form) notation, namely symbols like `|`, `::=`, `>`, and `<` are used to define production rules.
  - Because this is a binary format, the only terminal symbols are bytes, which we write in hexadecimal notation `0x00`, `0x01`, ..., and `0xff`.
  - Parentheses `(` and `)` enclose a tuple.
- - Brackets `[` and `]` are used to index an element of a tuple, for example the `i`th element of tuple `T` is denoted `T[i]`.
- - Brackets following a variable named `bitmask` means that the index is of a bit, e.g. `bitmask[0]` represents the leftmost bit.
+ - Brackets `[` and `]` are used to index an element of a tuple. `T[i]` denotes the `i`th element of `n`-tuple `T`, where `i` is either `0`, `1`, ..., or `n-1`. The tuple can be of any elements. Notably, we use a variable named `bitmask` for a tuple of bits, e.g. `bitmask[0]` represents the leftmost bit.
  - Ellipses `...` are notation for "and so on until", and are used to avoid writing a long enumerated tuple. For example, `A[1] A[2] ... A[5]` is short-hand notation for `A[1] A[2] A[3] A[4] A[5]`.
- - `A^n` represents symbol `A` repeated `n` times. We allow `n` to be `0`, representing zero occurrences of `A`. Also, if there is a logical expression in place of `n`, then a false expression is replaced by `0` and a true expression is replaced with `1`.
+ - `A^n` represents symbol `A` repeated `n` times. We allow `n` to be `0`, representing zero occurrences of `A`.
  - `A^+` represents symbol `A` repeated one or more times.
  - `A^*` represents symbol `A` repeated zero or more times.
- - Curly braces `{` and `}` enclose semantics after each syntax rule.
- - Semantics are just an English explanation of what is produced by that syntax rule.
- - After each semantics rule, an optional validation rule starts with `Where` and ends with `.`. These extra restrictions may not be easily rendered in the syntax without introducing much more notation, which we wish to avoid.
+ - Curly braces `{` and `}` after each syntax rule enclose semantics, which describe what is produced by that syntax rule.
+ - After each semantics rule, an optional validation rule starts with `Where` and ends with `.`. These validation rules are extra restrictions on the syntax or semantics. Perhaps these restrictions can be rendered directly in syntax or semantics rules, but using validation rules is more concise.
  - Whitespace between a syntax rule, semantics rule, and validation rule is arbitrary, and could include new lines and indentation for aesthetics.
 - `x:<Non-terminal>` means that we bind variable `x` to whatever is produced by non-terminal `<Non-terminal>`. We use this variable in the syntax or semantics of this rule.
  - A syntax rule starting with `<Non-terminal1(0<=n<64)>` is a parameterization of different syntax rules for `<Non-terminal1(0)>`, `<Non-terminal1(1)>`, ..., `<Non-terminal1(63)>`, each with the same structure, but using symbol `n` as a bound variable later in the syntax rule, and in corresponding semantics and validation rules. When this non-terminal is used after the `:=`, the specific parameter is given like `<Non-terminal1(k)>` where `k` is a non-negative integer up to 63 or an arithmetic expression in terms of bound variables. This notation is generalized for multiple parameters, using a comma to separate parameters, `<Non-terminal2(0<=d<65,0<=s<2)>`.
- - In place of a variable, there may be an arithmetic or logical expression in terms of bound variables. The expression is evaluated to an integer. For example, `A^n-7` represents `A` repeated `n-7` times, where `n` is a bound variable representing an integer. For logical expression, a false expression evaluates to `0` and a true expression evaluates to `1`. We omit defining the structure of expressions, we just use standard notation for binary infix operations `+`, `-`, `*`, modulo `%`, floor division `//`. Logical expressions use binary infix relations `<`, `>`, `<=`, `>=`, and `==`, evaluating to integer `0` if false and `1` if true. Order of operations is standard, and parentheses `(`, `)` enclose expressions to be evaluated first.
- - `||` between byte arrays means concatenation.
- - Function `numbits()` takes a byte and outputs the number of bits set to `1`.
+ - In place of a variable, there may be an arithmetic or logical expression in terms of bound variables. The expression is evaluated to an integer. For example, `A^(n-7)` represents `A` repeated `n-7` times, where `n` is a bound variable representing a non-negative integer. We omit defining the structure of arithmetic expressions, we just use standard notation for binary infix operations `+`, `-`, `*`, modulo `%`, floor division `//`. Logical expressions use binary infix relations `<`, `>`, `<=`, `>=`, and `==`, evaluating to integer `0` if false and `1` if true. Order of operations is standard, and parentheses `(`, `)` enclose expressions to be evaluated first.
+ - `||` between bytes or byte arrays means concatenation.
+ - Function `numbits()` takes a byte or tuple of bytes, and outputs the number of bits set to `1`.
 
 
 ## 2.2. Definition of the Syntax, Semantics, and Validation Rules
@@ -133,45 +131,27 @@ The only terminal symbols are 8-bit bytes, represented in hexadecimal notation. 
         | 0xff        {byte with value 0xff}
 ```
 
-First define some non-terminals to simplify later definitions.
+Define some non-terminals to simplify later definitions. The rule for `Nibbles` pads the final byte with zero bits if there are an odd number of nibbles.
 
 ```
-<Bytes32> ::= b:<Byte>^32	{byte array b in big-endian}
+<Bytes2> ::= b:<Byte>^2          {byte array b in big-endian}
 
-<Address> ::= b:<Byte>^20	{byte array b in big-endian}
+<Bytes32> ::= b:<Byte>^32        {byte array b in big-endian}
+
+<Address> ::= b:<Byte>^20        {byte array b in big-endian}
 
 <Byte_Nonzero> ::= 0x01          {byte with value 0x01}
-                | 0x02          {byte with value 0x02}
-                | ...
-                | 0xff          {byte with value 0xff}
+                 | 0x02          {byte with value 0x02}
+                 | ...
+                 | 0xff          {byte with value 0xff}
 
-<Byte_More_Than_One_Bit_Set> ::= 0x03          {byte with value 0x03}
-                              | 0x05          {byte with value 0x05}
-                              | 0x06          {byte with value 0x06}
-                              | 0x07          {byte with value 0x07}
-                              | 0x09          {byte with value 0x09}
-                              | 0x0a          {byte with value 0x0a}
-                              | ...
-                              | 0x0f          {byte with value 0x0f}
-                              | 0x11          {byte with value 0x11}
-                              | 0x12          {byte with value 0x12}
-                              | ...
-                              | 0xff          {byte with value 0xff}
-
-<Bytes2_More_Than_One_Bit_Set> ::= b1:<Byte> b2case1:<Byte>^numbits(b1)>1 b2case2:<Byte_Nonzero>^numbits(b1)==1 b2case3:<Byte_More_Than_One_Bit_Set>^numbits(b1)==0
-                                  {byte array b1||b2case1||b2case2||b2case3}
-
-<Byte_Lower_Nibble_Zero> ::= 0x00    {byte with value 0x00}
-                          | 0x10    {byte with value 0x10}
-                          | ...
-                          | 0xf0    {byte with value 0xf0}
-
-<Nibbles(0<=n<65)> ::= nibbles:<Byte>^(n//2) overflownibble:<Byte_Lower_Nibble_Zero>^(n%2)
+<Nibbles(0<=n<65)> ::= nibbles:<Byte>^(n//2) overflownibble:<Byte>^(n%2)
                        {byte array nibbles||overflownibble}
+                       Where `overflownibble`, if it is non-empty, has its least significant 4 bits set to zero.
 ```
 
 
-Next, a variable-length integer encoding. [LEB128](https://en.wikipedia.org/wiki/LEB128#Unsigned_LEB128) with the restriction that the most-significant "chunk" is non-zero.
+Next, a variable-length integer encoding. [LEB128](https://en.wikipedia.org/wiki/LEB128#Unsigned_LEB128), with the restriction that the most-significant "chunk" is non-zero. We use `>>` and `<<` as the standard logical bit-shift operators.
 
 ```
 Integer(0<n<=256) ::= low:<Byte> high:<Integer(n-7)>^(low>>7)
@@ -190,15 +170,10 @@ The designated starting non-terminal is `<Block_Witness>`.
 <Version> ::= 0x01
              {the version byte 0x01}
 
-<Tree> := m:<Metadata> n:<Tree_Node(0)>
-          {a tuple (m, n)}
-
-<Metadata> ::= 0x00
-              {nothing}
-            | 0x01 lenid:<Integer(32)> id:<Byte>^lenid lendata:<Integer(32)> data:<Byte>^lendata
-              {a tuple (id, data)}
-              Where the 0x01 case is disallowed in a block witnesses, but allowed for extending this spec.
+<Tree> ::= 0x00 n:<Tree_Node(0)>
+           {tree root node n}
 ```
+The rule for `Tree` includes an unused byte `0x00` which may be used in the future to extend the spec in a backwards-compatible way.
 
 Next, recursively define the encoding for all Ethereum trie nodes, with some nodes possibly replaced by their merkle hash. Following the yellowpaper section 4.1 and appendix D, the trie has three types of nodes: branch, extension, and leaf. Add a fourth type of node which can replace any node with the merkle hash of the subtrie rooted at that node. Note that the parametrization variable `d` represents the nibble-depth and `s` represents a flag which is `0` when this node is in the account trie and `1` when in a storage trie.
 
@@ -212,8 +187,9 @@ Next, recursively define the encoding for all Ethereum trie nodes, with some nod
                               | 0x03 h:<Bytes32>
                                 {hash node with merkle hash h}
 
-<Branch_Node(0<=d<64,0<=s<2)> ::= bitmask:<Bytes2_More_Than_One_Bit_Set> c[0]:<Tree_Node(d+1,s)>^bitmask[0]==1 c[1]:<Tree_Node(d+1,s)>^bitmask[1]==1 ... c[15]:<Tree_Node(d+1,s)>^bitmask[15]==1
+<Branch_Node(0<=d<64,0<=s<2)> ::= bitmask:<Bytes2> c[0]:<Tree_Node(d+1,s)>^(bitmask[0]==1) c[1]:<Tree_Node(d+1,s)>^(bitmask[1]==1) ... c[15]:<Tree_Node(d+1,s)>^(bitmask[15]==1)
                                   {branch node with children nodes (c[0], c[1], ..., c[15]), note that some children may be empty based on the bitmask}
+                                  Where numbits(`bitmask`)>=2.
 
 <Extension_Node(0<=d<63,0<=s<2)> ::= nibbleslen:<Byte_Nonzero> nibbles:<Nibbles(nibbleslen)> child:<Child_Of_Extension_Node(d+nibbleslen,s)>
                                      {extension node with values (nibbleslen, nibbles, child)}
@@ -223,22 +199,22 @@ Next, recursively define the encoding for all Ethereum trie nodes, with some nod
                                             | 0x03 h:<Bytes32>
                                               {hash node with merkle hash h}
 
-<Leaf_Node(0<=d<65,0<=s<2)> ::= accountleaf:<Account_Node(d)>^s==0 storageleaf:<Storage_Leaf_Node(d)>^s==1
+<Leaf_Node(0<=d<65,0<=s<2)> ::= accountleaf:<Account_Node(d)>^(s==0) storageleaf:<Storage_Leaf_Node(d)>^(s==1)
                                 {leaf node accountleaf or storageleaf, depending on whether s==0 or s==1}
 
-<Account_Node(0<=d<65)> := 0x00 address:<Address> balance:<Integer(256)> nonce:<Integer(256)>
-                           {externally owned account node with values (address, balance, nonce)}
-                         | 0x01 address:<Address> balance:<Integer(256)> nonce:<Integer(256)> bytecode:<Bytecode> storage:<Tree_Node(0,1)>
-                           {contract account node with values (address balance nonce bytecode storage)}
+<Account_Node(0<=d<65)> ::= 0x00 address:<Address> balance:<Integer(256)> nonce:<Integer(256)>
+                            {externally owned account node with values (address, balance, nonce)}
+                          | 0x01 address:<Address> balance:<Integer(256)> nonce:<Integer(256)> bytecode:<Bytecode> storage:<Tree_Node(0,1)>
+                            {contract account node with values (address balance nonce bytecode storage)}
 
-<Bytecode> := 0x00 codelen:<Integer(32)> b:<Byte>^codelen
-              {byte array b of length codelen}
-              Where code b must be accessed in the block, otherwise use case 0x01.
-            | 0x01 codelen:<Integer(32)> codehash:<Bytes32>
-              {tuple (codelen, codehash)}
+<Bytecode> ::= 0x00 codelen:<Integer(32)> b:<Byte>^codelen
+               {byte array b of length codelen}
+               Where code b must be accessed in the block, otherwise use case 0x01.
+             | 0x01 codelen:<Integer(32)> codehash:<Bytes32>
+               {tuple (codelen, codehash)}
 
-<Storage_Leaf_Node(0<=d<65)> := key:<Bytes32> val:<Bytes32>
-                                {leaf node with value (key, val)}
+<Storage_Leaf_Node(0<=d<65)> ::= key:<Bytes32> val:<Bytes32>
+                                 {leaf node with value (key, val)}
 ```
 
 


### PR DESCRIPTION
This patch does _not_ change the binary encoding. It makes the definitions more concise, clear, and readable.

* Merge bullet-points for bracket `[` `]` notation, specifying the the special case for `bitmask` as an example.
* Clarify notation for semantics.
* Replace complicated syntax rules with validation rules. Allows completely removing some syntax rules like like `Bytes_More...`.
* Parentheses around arithmetic expressions, to avoid ambiguity.
* Clarify definition of `numbits()`.
* Clearer LEB128 description.
* Remove Metadata section, leaving the `0x00` byte to allow extending the witness spec with a metadata section or anything else.
* Finish `:=`->`::=` conversion, and reallign some rules after extra space for `::=`.