### PR TITLE
Add Discord invitation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Stateless Ethereum is the "all in" direction of Ethereum 1.x research to solve t
 
 **[Ethresear.ch (tag: "1.x research")](https://ethresear.ch/c/eth1x-research/37)**
 
-**[Eth1x / 2 Research Discord]()** 
+**[Eth1x / 2 Research Discord](https://discord.gg/hpFs23p)** 
 
 
 


### PR DESCRIPTION
Hi, the Discord link in the README was blank, so I went on "[Ethereum 2.0 Devs Handbook and FAQs](https://notes.ethereum.org/@serenity/handbook)" and I filled out the invitation link that is there. 
I'm sorry if for some reason you have left it blank :)