### PR TITLE
Update state network spec

### DIFF
--- a/state-network.md
+++ b/state-network.md
@@ -6,8 +6,8 @@ This document is intended to serve as a preliminary specification for the networ
 
 We define the Ethereum "State" to be the collection of:
 
-- Accounts from the main account trie referenced by `Header.state_root`
-- The set of all contract storage tries referenced by `Account.state_root`
+- Accounts and intermediate trie data from the main account trie referenced by `Header.state_root`
+- The set of all contract storage values and intermediate trie data referenced by `Account.state_root`
 - The set of all contract bytecodes referenced by `Account.code_hash`
 
 ## Overview
@@ -15,20 +15,14 @@ We define the Ethereum "State" to be the collection of:
 The network(s) that support "on-demand" availability of the Ethereum state must do the following things.
 
 - Retrieval:
-    - A: Mechanism for finding and retrieving "state" data.
+    - A: Mechanism for finding and retrieving recent "state" data.  This must also include proof of exclusion for non-existent data.
 - Storage:
-    - B: Mechanism for *new* state data to be distributed to *interested* nodes in a provable manner.
-    - C: Mechanism for *new* nodes joining the network to discover existing state data that is *interesting* to them.
-    - D: Mechanism for *missing* state data to be distributed to *interested* nodes
+    - B: Mechanism for state data to be distributed to *interested* nodes in a provable manner.
     
     
-We solve A with a standard Kademlia DHT using the "recursive find" algorithm.
+We solve A by mapping "state" data onto the Kademlia DHT such that nodes can determine the location in the network where a particular piece of state should be stored.  With a standard Kademlia DHT using the "recursive find" algorithm any node in the network can quickly find nodes that should be storing the data they are interested in.
 
-We solve B with a gossip network and merkle proofs.
-
-We ignore C because it can be handled via a combination of POKE and the solution for D
-
-We solve D without any modification to the protocol, by simply having a daemon that searches for missing state and injects it into the network using standard gossip mechanics
+We solve B with a structured gossip algorithm that distributes the individual trie node data across the nodes in the DHT.  As the chain progresses, a witness of the new and updated state data will be generated at each new `Header.state_root`.  The individual trie nodes from this witness would then be distributed to the appropriate DHT nodes.
 
 
 ## DHT Network
@@ -37,106 +31,114 @@ Our DHT will be an overlay network on the existing [Discovery V5](https://github
 
 The identifier `0xTODO` will be used as the `protocol_id` for TALKREQ and TALKRESP messages.
 
-Nodes **must** support the `utp` Discovery v5 protocol.
+Nodes **must** support the `utp` Discovery v5 protocol to facilitate transmission of merkle proofs which will in most cases exceed the UDP packet size.
 
-We use the same distance function as the core protocol.
+We use a custom distance function defined below.
 
-We use the same routing table structure as the core protocol.
+We use the same routing table structure as the core protocol.  The routing table must use the custom distance function defined below.
 
 We use the same PING/PONG/FINDNODES/NODES messaging rules as the core protocol.
 
-### Content
+### Content Keys and Content IDs
 
-All content on the network has a key and a value.  The keys are referred to as `content_key`.  The value is referred to using the variable `content`. Each piece of content has a `content_id` which is derived from the `content_key` as `hash(content_key)`.
+The network supports the following schemes for addressing different types of content.
 
-> TODO: define `hash` function (probably sha256)
+All content keys are the concatenation of a 1-byte `content_type` and a serialized SSZ `Container` object.  The `content_type` indicate which type of content key the payload represents.  The SSZ `Container` sedes defines how the payload can be decoded.
 
-> TODO: define serialization for content keys
+We define a custom SSZ sedes alias `Nibbles` to mean `List[uint8, max_length=64]` where each individual value **must** be constrained to a valid "nibbles" value of `0 - 15`.
 
-The data stored in the network is referred to as "content".  The network houses three different types of content.
+#### Account Trie Nodes
 
-- Account trie data
-- Contract storage trie data
-- Contract bytecode
+> TODO: consult on best way to define trie paths
+```
+0x00 | Container(path: Nibbles, node_hash: bytes32, state_root: bytes32)
 
-> TODO: encoding scheme for trie paths that accounts for nibbles: https://github.com/ethereum/py-trie/blob/6da013af84f5448b30abe81a6e7ada07400b7a55/trie/utils/nibbles.py
-
-
-#### Account Trie Data
+content_id := sha256(path | node_hash)
 
 ```
-content_key  := network_id | content_type | trie_path | node_hash
-network_id   := uint16
-content_type := 0x01
-trie_path    := nibbles (TODO)
-node_hash    := hash(content)
-```
 
-The SSZ sedes used for encoding/decoding
+#### Contract Storage Trie Nodes
 
 ```
-Container(network_id: uint16, content_type: uint8, trie_path: byte_list, node_hash: bytes32)
+0x01 | Container(address: bytes20, path: Nibbles, node_hash: bytes32, state_root: bytes32)
+
+content_id := sha256(address | path | node_hash)
 ```
 
 
-#### Contract Storage Trie Data
+#### Account Trie Leaves
 
 ```
-content_key  := network_id | content_type | address | trie_path | node_hash
-network_id   := uint16
-content_type := 0x02
-address      := bytes20
-trie_path    := nibbles (TODO)
-node_hash    := hash(content)
+0x02 | Container(address: bytes20, state_root: bytes32)
+
+content_id := keccak(address)
 ```
 
-The SSZ sedes used for encoding/decoding
+
+#### Contract Storage Trie Leaves
 
 ```
-Container(network_id: uint16, content_type: uint8, address: bytes20, trie_path: byte_list, node_hash: bytes32)
-```
+0x03 | Container(address: bytes20, slot: uint256, state_root: bytes32)
 
+content_id := (keccak(address) + keccak(slot)) % 2**256
+```
 
 #### Contract Bytecode
 
 ```
-content_key  := network_id | content_type | address | code_hash
-network_id   := uint16
-content_type := 0x03
-address      := bytes20
-code_hash    := keccak(content)
+0x04 | Container(address: bytes20, code_hash: bytes32)
+
+content_id := sha256(address | code_hash)
 ```
 
-The SSZ sedes used for encoding/decoding
+
+### Distance Function
+
+The overlay DHT uses the following distance function for determining both:
+
+* The distance between two DHT nodes in the network.
+* The distance between a DHT node and a piece of content.
+
+```python
+MODULO = 2**256
+MID = 2**255
+
+def distance(node_id: int, content_id: int) -> int:
+    """
+    Source: https://stackoverflow.com/questions/28036652/finding-the-shortest-distance-between-two-angles
+    
+    A distance function for determining proximity between a node and content.
+    
+    Treats the keyspace as if it wraps around on both ends and 
+    returns the minimum distance needed to traverse between two 
+    different keys.
+    
+    Examples:
+
+    >>> assert distance(10, 10) == 0
+    >>> assert distance(5, 2**256 - 1) == 6
+    >>> assert distance(2**256 - 1, 6) == 7
+    >>> assert distance(5, 1) == 4
+    >>> assert distance(1, 5) == 4
+    >>> assert distance(0, 2**255) == 2**255
+    >>> assert distance(0, 2**255 + 1) == 2**255 - 1
+    """
+    delta = (node_id - content_id + MID) % MODULO - MID
+    if delta  < -MID:
+        return abs(delta + MID)
+    else:
+        return abs(delta)
 
 ```
-Container(network_id: uint16, content_type: uint8, address: bytes20, code_hash: bytes32)
-```
 
-### Radius
-
-Nodes on the network broadcast a `radius` value which is used to advertise how much of the overall trie data a node stores.  `radius` is a 256 bit integer.  We define `MAX_RADIUS = 2**256 - 1`
-
-A node is expected to be *interested* in a piece of content if `distance(node_id, content_id) <= radius`.
-
-Nodes are expected to track the radius of other nodes on the network.
+This distance function is designed to preserve locality of leaf data within main account trie and the individual contract storage tries.  The term "locality" in this context means that two trie nodes which are adjacent to each other in the trie will also be adjacent to each other in the DHT.
 
 
-### Gossip
+#### Radius
 
-Nodes in the network should use the following rules for gossip.
+Nodes on the network will be responsible for tracking and publishing a `radius` value to their peers.  This value serves as both a signal about what data a node should be interested in storing, as well as what data a node can be expected to have.  The `radius` is a 256 bit integer.  We define `MAX_RADIUS = 2**256 - 1`
 
-TODO: outline the process of receiving a proof and: 1) extracting the parent proofs, and re-advertising them to the nodes in the network they expect to be interested in them as well as 2) relaying the base proof to neighbor nodes that should be interested.
-
-### POKE
-
-The standard process of looking up content is a depth first traversal of the trie towards the desired path, iteratively building a "proof".
-
-At each stage, a node is likely to encounter nodes who are "interested" in the content, but who did not have it.
-
-Once the content has been required, nodes are encouraged to POKE the assembled proof back to these nodes.  This would use the same gossip mechanisms.
-
-This POKE mechanic actively spreads propular content through the network.
+A node is said to be *"interested"* in a piece of content if `distance(node_id, content_id) <= radius`.  Nodes are expected to store content they are "interested" in.
 
 
 ### Wire Protocol
@@ -255,53 +257,72 @@ sedes      := Container(enrs: List[byte_list, max_length=32], payload: byte_list
 > A response with an empty `payload` and empty `enrs` indicates that the node is not aware of any closer nodes, *nor* does the node have the requested content.
 
 
-#### Advertise (0x07)
+#### Offer (0x07)
 
-Advertise a set of content keys that this node has proofs available for.
+Offer a set of content keys that this node has proofs available for.
 
 ```
 message_id := 7
 type       := request
-sedes      := List[byte_list, max_length=32]
+sedes      := List[byte_list, max_length=64]
 ```
 
 The payload of this message is a list of encoded `content_key` entries.
 
 
-#### RequestProofs (0x08)
+#### Accept (0x08)
 
-Response message to Advertise (0x07).
+Response message to Offer (0x07).
 
-Request the proofs for a piece of content.
+Signals interest in receiving the offered data fro the corresponding Offer message.
 
-> Despite the name of this message having the name "Request" in it, this is a response message.
 
 ```
 message_id := 8
 type       := response
-sedes      := Container(connection_id: bytes4, content_keys: List[byte_list, max_length=32]]
+sedes      := Container(connection_id: bytes4, content_keys: BitList[max_length=64]]
 ```
 
 * `connection_id`: ConnectionID to be used for a uTP stream
     * ConnectionID values should be randomly generated.
-* `content_keys`: The set of encoded content keys that should be sent.
-    * Only content keys from the corresponding Advertise message are valid.
+* `content_keys`: Signals which content keys are desired
+    * A bit-list corresponding to the offered keys with the bits in the positions of the desired keys set to `1`.
 
 Upon *sending* this message, the requesting node should *listen* for an incoming uTP stream with the generated `connection_id`.
 
 Upon *receiving* this message, the serving node should initiate a uTP stream.
 
-Proofs sent across the stream should be framed with a 4-byte length prefix.
+> TODO: how does message framing across the stream work for individual messages.
 
-```
-message_frame := length_prefix | message
-length_prefix := bytes4
-message       := encode(proof)
-proof         := TBD
-```
 
-> The exact semantics of how we encode proofs are under active development and subject to major changes.
+### Gossip
 
-We encode proofs as a stream of `(path, node)` pairs which have been sorted in preorder traversal ordering.  We can save some bytes by de-duplicating the `path` components since each path will tend to have a common prefix with the previous path.
+The state network uses "structured" gossip to push new state data into the storage of individual DHT nodes.  We refer to the concept of a "bridge" node in the network to mean a node which is acting benevolently to bring new and updated state data into the network.
 
-We also validate that proofs are "minimal", only containing the minimal set of trie nodes necessary for the proven piece of data.
+* At each block we define our witness to be:
+    * The set of all accounts that were created or modified
+    * The set of all contract storage slots that were created or modified
+    * The set of all contract bytecodes that were created.
+* A traditional "full" node with a fully synced state database will typically be used to construct this witness.
+* The witness is then deconstructed into its individual trie nodes and their corresponding sub-proofs to anchor them in a provable manner to the `Header.state_root`
+* For each individual trie node and its corresponding proof the bridge node will compute the corresponding `content_id`, seek out DHT nodes who's area of interest contains this `content_id`, and will offer those DHT nodes the data.
+
+> TODO: 1: efficiency thing where bridge is only reasponsible for leaf data and nodes handle recursive sub-proof gossip.
+
+> TODO: 2: bridge nodes need to do gossip for contract storage leaves.
+
+> TODO: 3: bridge nodes need to do gossip for contract bytecodes
+
+- bridge does *all* GetNodeData style gossip.
+    - this could be reduced by only gossiping nodes from the edge of the proof, and delegating intermediate node gossip.
+- bridge does all contract leaf gossip.
+    - this *could* be done by the nodes that receive the contract storage leaves as GetNodeData style data.
+- bridge does contract bytecodes gossip.
+
+
+
+### POKE
+
+> TODO: Discribe this mechanism
+
+


### PR DESCRIPTION
### What is wrong

The current state network spec has not been updated with the latest network changes

### How was it fixed

- document that data is stored in two different formats
- document the content key and content-id formulas for both trie nodes and leaf proofs
- document the gossip mechanism